### PR TITLE
Spilt MixinEntityRenderer OptiFine portion into own Mixin

### DIFF
--- a/src/main/java/carpetclient/mixinInterface/AMixinEntityRenderer.java
+++ b/src/main/java/carpetclient/mixinInterface/AMixinEntityRenderer.java
@@ -1,0 +1,8 @@
+package carpetclient.mixinInterface;
+
+/**
+ * Duck interface for MixinEntityRenderer.java
+ */
+public interface AMixinEntityRenderer {
+    float partialTicksPlayer(float partialTicksWorld);
+}

--- a/src/main/java/carpetclient/mixins/optifine/MixinEntityRendererOptifine.java
+++ b/src/main/java/carpetclient/mixins/optifine/MixinEntityRendererOptifine.java
@@ -1,0 +1,28 @@
+package carpetclient.mixins.optifine;
+
+import carpetclient.mixinInterface.AMixinEntityRenderer;
+import net.minecraft.client.renderer.EntityRenderer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(EntityRenderer.class)
+public abstract class MixinEntityRendererOptifine {
+    /**
+     * fix tick rate rendering glitch rendering view bobbing, OptiFine additional patch
+     *
+     * method prototype is:
+     * public void renderHand(float partialTicks, int pass, boolean renderItem, boolean renderOverlay, boolean renderTranslucent)
+     *
+     * Method name not obfuscated, so cannot be patched by MixinEntityRenderer::tickratePlayerBobbing
+     * The signature is not declared here in @ModifyArg method parameter to silence compilation warning.
+     *
+     * Also, for some reason, if `remap = true` is omitted in @At then refmap don't
+     * generate with entry for this injection point, causing silent(!) injection failure.
+     */
+    @ModifyArg(method = "renderHand", index = 0, remap = false, require = 0,
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/EntityRenderer;applyBobbing(F)V", remap = true))
+    private float tickratePlayerBobbingOptiFine(float partialTicksWorld) {
+        return ((AMixinEntityRenderer) this).partialTicksPlayer(partialTicksWorld);
+    }
+}

--- a/src/main/resources/mixins.carpetclient.optifinecompat.json
+++ b/src/main/resources/mixins.carpetclient.optifinecompat.json
@@ -4,6 +4,7 @@
   "refmap": "mixins.carpetclient.refmap.json",
   "plugin": "carpetclient.mixins.optifine.OptifinePlugin",
   "mixins": [
+    "optifine.MixinEntityRendererOptifine",
     "optifine.MixinRenderChunkOptifine"
   ]
 }


### PR DESCRIPTION
`require = 0` would only really make the mixin optional in Mixin 0.8,
after SpongePowered/Mixin#297. Stock Liteloader is bundled with
Mixin 0.7.5, which raises an error if the mixin target method, which
is added by OptiFine, cannot be found, even with `require = 0`.