### PR TITLE
Updated build.gradle's maven's urls and added rotation for dispensers and droppers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,11 +8,11 @@ buildscript {
         }
         maven {
             name = "forge"
-            url = "http://files.minecraftforge.net/maven"
+            url = "https://files.minecraftforge.net/maven"
         }
         maven {
             name = 'sponge'
-            url = 'http://repo.spongepowered.org/maven'
+            url = 'https://repo.spongepowered.org/repository/maven-public/'
         }
         jcenter()
     }
@@ -24,7 +24,7 @@ buildscript {
 
 apply plugin: 'java'
 
-version = "v1.4d"
+version = "v1.4d." + new Date().format('yyMMdd')
 group = "Carpet Team"
 archivesBaseName = "Carpet Client"
 
@@ -81,7 +81,7 @@ runClient {
 }*/
 
 repositories {
-    maven { url = "http://repo.spongepowered.org/maven" }
+    maven { url = "https://repo.spongepowered.org/repository/maven-public/" }
 }
 dependencies {
     compile 'org.jetbrains.java.decompiler:fernflower:sponge-SNAPSHOT'

--- a/src/main/java/carpetclient/mixins/MixinBlockDispenser.java
+++ b/src/main/java/carpetclient/mixins/MixinBlockDispenser.java
@@ -1,0 +1,52 @@
+package carpetclient.mixins;
+
+import carpetclient.Config;
+import carpetclient.Hotkeys;
+import net.minecraft.block.BlockContainer;
+import net.minecraft.block.BlockDispenser;
+
+import net.minecraft.block.material.Material;
+import net.minecraft.block.properties.PropertyBool;
+import net.minecraft.block.properties.PropertyDirection;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(BlockDispenser.class)
+public abstract class MixinBlockDispenser extends BlockContainer {
+
+    @Shadow
+    public static @Final
+    PropertyDirection FACING;
+
+    @Shadow
+    public static @Final
+    PropertyBool TRIGGERED;
+
+    protected MixinBlockDispenser(Material materialIn) {
+        super(materialIn);
+    }
+
+    @Inject(method = "getStateForPlacement", at = @At("HEAD"), cancellable = true)
+    public void canPlaceOnOver(World worldIn, BlockPos pos, EnumFacing facing, float hitX, float hitY, float hitZ, int meta, EntityLivingBase placer, CallbackInfoReturnable<IBlockState> cir) {
+        if (Config.accurateBlockPlacement) {
+            if (!Hotkeys.isKeyDown(Hotkeys.toggleBlockFacing.getKeyCode())) {
+                facing = EnumFacing.getDirectionFromEntityLiving(pos, placer).getOpposite();
+            }
+            if (!Hotkeys.isKeyDown(Hotkeys.toggleBlockFlip.getKeyCode())) {
+                facing = facing.getOpposite();
+            }
+        } else {
+            facing = EnumFacing.getDirectionFromEntityLiving(pos, placer);
+        }
+        cir.setReturnValue(this.getDefaultState().withProperty(FACING, facing).withProperty(TRIGGERED, Boolean.valueOf(false)));
+    }
+}

--- a/src/main/java/carpetclient/mixins/MixinPlayerControllerMP.java
+++ b/src/main/java/carpetclient/mixins/MixinPlayerControllerMP.java
@@ -121,7 +121,7 @@ public class MixinPlayerControllerMP {
 
         if (Hotkeys.isKeyDown(Hotkeys.toggleBlockFacing.getKeyCode())) {
             // rotate pistons for placing head into blocks
-            if (isPiston(itemstack)) {
+            if (isPiston(itemstack) || isDispenser(itemstack)) {
                 direction = direction.getOpposite();
             }
 

--- a/src/main/resources/mixins.carpetclient.json
+++ b/src/main/resources/mixins.carpetclient.json
@@ -10,6 +10,7 @@
     "MixinPlayerControllerMP",
     "MixinBlockObserver",
     "MixinBlockPistonBase",
+    "MixinBlockDispenser",
     "MixinBlockRedstoneComparator",
     "MixinBlockRedstoneDiode",
     "MixinEntity",


### PR DESCRIPTION
Droppers and dispensers alredy rotated, but client didn't noticed, if you had ping on servers client would first place it the normal way and then it would be rotated